### PR TITLE
develop: ReplaceJob 추가, options 저장 자료구조 변경

### DIFF
--- a/src/main/java/com/zziri/logcut/job/CutJob.java
+++ b/src/main/java/com/zziri/logcut/job/CutJob.java
@@ -22,8 +22,8 @@ public class CutJob extends Job {
 
     @Override
     public List<String> run(List<String> lines) {
-        Pattern startPattern = Pattern.compile(options.get(0));
-        Pattern endPattern = Pattern.compile(options.get(1));
+        Pattern startPattern = Pattern.compile(options.poll());
+        Pattern endPattern = Pattern.compile(options.poll());
 
         log.info(String.format("cutting by pattern from %s to %s", startPattern.toString(), endPattern.toString()));
 

--- a/src/main/java/com/zziri/logcut/job/InputJob.java
+++ b/src/main/java/com/zziri/logcut/job/InputJob.java
@@ -25,7 +25,7 @@ public class InputJob extends Job {
     public List<String> run(List<String> lines) {
         List<String> ret = new ArrayList<>();
         try {
-            ret = Files.readAllLines(Paths.get(options.get(0)).toAbsolutePath(), StandardCharsets.ISO_8859_1);
+            ret = Files.readAllLines(Paths.get(options.poll()).toAbsolutePath(), StandardCharsets.ISO_8859_1);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/zziri/logcut/job/Job.java
+++ b/src/main/java/com/zziri/logcut/job/Job.java
@@ -1,17 +1,19 @@
 package com.zziri.logcut.job;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 
 public abstract class Job {
-    protected List<String> options;
+    protected Queue<String> options;
     public abstract int getNumberOfOptions();
     public abstract String getName();
     public abstract List<String> run(List<String> lines);
 
     public void addOption(String option) {
         if (options == null)
-            options = new ArrayList<>();
+            options = new LinkedList<>();
         options.add(option);
     }
 }

--- a/src/main/java/com/zziri/logcut/job/OutputJob.java
+++ b/src/main/java/com/zziri/logcut/job/OutputJob.java
@@ -23,7 +23,7 @@ public class OutputJob extends Job {
     @Override
     public List<String> run(List<String> lines) {
         try {
-            Files.write(Paths.get(options.get(0)).toAbsolutePath(), lines, StandardCharsets.ISO_8859_1);
+            Files.write(Paths.get(options.poll()).toAbsolutePath(), lines, StandardCharsets.ISO_8859_1);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/zziri/logcut/job/RangeJob.java
+++ b/src/main/java/com/zziri/logcut/job/RangeJob.java
@@ -23,8 +23,8 @@ public class RangeJob extends Job {
 
     @Override
     public List<String> run(List<String> lines) {
-        String low = options.get(0);
-        String high = options.get(1);
+        String low = options.poll();
+        String high = options.poll();
 
         if (low.compareTo(high) > 0) {
             log.error("Please check the order of parameters");

--- a/src/main/java/com/zziri/logcut/job/ReplaceJob.java
+++ b/src/main/java/com/zziri/logcut/job/ReplaceJob.java
@@ -5,23 +5,26 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class PrefixJob extends Job {
+public class ReplaceJob extends Job {
     @Override
     public int getNumberOfOptions() {
-        return 1;
+        return 2;
     }
 
     @Override
     public String getName() {
-        return "prefix";
+        return "replace";
     }
 
     @Override
     public List<String> run(List<String> lines) {
-        String prefix = options.poll();
+        String src = options.poll();
+        String dst = options.poll();
+
         for (int i=0; i<lines.size(); i++) {
-            lines.set(i, prefix + lines.get(i));
+            lines.set(i, lines.get(i).replaceAll(src, dst));
         }
+
         return lines;
     }
 }


### PR DESCRIPTION
정규식으로 찾아서 바꾸는 ReplaceJob 추가
같은 종류의 Job이 Pipeline에 2개 이상 있을 수 있음
그래서 options를 queue로 바꾸어 순차적으로 꺼내도록 수정